### PR TITLE
Make Route53 ADD/DELETE cache TTL configurable to reduce API call frequency

### DIFF
--- a/config.go
+++ b/config.go
@@ -155,8 +155,10 @@ type Host struct {
 }
 
 type Link struct {
-	HostedZoneID           string   `yaml:"hosted_zone_id"`
-	DefaultTaskDefinitions []string `yaml:"default_task_definitions"`
+	HostedZoneID           string        `yaml:"hosted_zone_id"`
+	DefaultTaskDefinitions []string      `yaml:"default_task_definitions"`
+	AddCacheTTL            time.Duration `yaml:"add_cache_ttl"`
+	DeleteCacheTTL         time.Duration `yaml:"delete_cache_ttl"`
 }
 
 type Listen struct {

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -44,6 +44,10 @@ ecs:
 # # enable link feature
 # link:
 #   hosted_zone_id: '{{ env "LINK_ZONE_ID" "Z00000000000000000000" }}'
+#   # TTL for Route53 ADD (UPSERT) operation cache (default: 5m)
+#   # add_cache_ttl: 5m
+#   # TTL for Route53 DELETE operation cache (default: 5m)
+#   # delete_cache_ttl: 5m
 #   # overwrite ecs.default_task_definition
 #   default_task_definitions:
 #     - '{{ env "DEFAULT_TASKDEF" "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/myapp" }}'

--- a/route53.go
+++ b/route53.go
@@ -12,12 +12,17 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/route53/types"
 )
 
+const DefaultDeleteCacheTTL = 5 * time.Minute
+const DefaultAddCacheTTL = 5 * time.Minute
+
 type Route53 struct {
-	svc          *route53.Client
-	changes      []*route53Change
-	hostedZoneID *string
-	zoneName     string
-	cache        *ttlcache.Cache
+	svc            *route53.Client
+	changes        []*route53Change
+	hostedZoneID   *string
+	zoneName       string
+	cache          *ttlcache.Cache
+	addCacheTTL    time.Duration
+	deleteCacheTTL time.Duration
 }
 
 type route53Change struct {
@@ -58,6 +63,18 @@ func NewRoute53(ctx context.Context, cfg *Config) *Route53 {
 	r.cache.SetTTL(5 * time.Minute)
 	r.cache.SkipTTLExtensionOnHit(true)
 
+	addCacheTTL := cfg.Link.AddCacheTTL
+	if addCacheTTL == 0 {
+		addCacheTTL = DefaultAddCacheTTL
+	}
+	r.addCacheTTL = addCacheTTL
+
+	deleteCacheTTL := cfg.Link.DeleteCacheTTL
+	if deleteCacheTTL == 0 {
+		deleteCacheTTL = DefaultDeleteCacheTTL
+	}
+	r.deleteCacheTTL = deleteCacheTTL
+
 	return r
 }
 
@@ -74,7 +91,7 @@ func (r *Route53) Add(name, addr string) {
 		slog.Debug(f("%s is cached. skip", key))
 		return
 	}
-	r.cache.Set(key, nil)
+	r.cache.SetWithTTL(key, nil, r.addCacheTTL)
 
 	slog.Debug(f("route53 change: %s", change.String()))
 	r.changes = append(r.changes, change)
@@ -94,7 +111,7 @@ func (r *Route53) Delete(name string, addr string) {
 		slog.Debug(f("%s is cached. skip", key))
 		return
 	}
-	r.cache.Set(key, nil)
+	r.cache.SetWithTTL(key, nil, r.deleteCacheTTL)
 
 	slog.Debug(f("route53 change: %s", change.String()))
 	r.changes = append(r.changes, change)


### PR DESCRIPTION
## Background / Problem

When launching a large number of tasks simultaneously in mirage, `ChangeResourceRecordSets` API calls are issued in rapid succession. According to the AWS documentation, Route 53 rejects subsequent requests for the same hosted zone if the prior request has not yet completed:

> "If Route 53 can't process a request before the next request arrives, it will reject subsequent requests for the same hosted zone and return an HTTP 400 error (`PriorRequestNotComplete`)."

In addition, Route 53 enforces a rate limit of **5 requests per second** per AWS account across all Route 53 API calls.

When a request is rejected, mirage does not retry — it simply logs the error and waits for the next ticker cycle (10 seconds). As a result, DNS records may fail to be created until the next cycle, which can appear as records staying unresolved for an extended period.

### Observed scenario

We experienced this issue when launching **7 tasks at once**, each with **2 sidecar containers**, as part of a per-PR environment setup using mirage. This results in a large number of Route 53 records being issued in a short window, which is enough to trigger the `PriorRequestNotComplete` error.

This problem is unlikely to occur in environments where only a small number of Route 53 records are issued at a time.

## Purpose of This Change

Rather than changing the default behavior, this PR makes the cache TTL for Route 53 `Add()` (UPSERT) and `Delete()` operations **configurable** via the `link` section of the config file.

By increasing the TTL, operators can reduce the frequency of API calls for environments that issue many records at once — while leaving the default behavior unchanged for typical use cases.

- Default value remains **5 minutes** (fully backward compatible)
- No behavior change unless explicitly configured

## Changes

- Add `add_cache_ttl` and `delete_cache_ttl` fields to the `Link` struct in config
- Add `addCacheTTL` and `deleteCacheTTL` fields to the `Route53` struct
- Replace `cache.Set()` with `cache.SetWithTTL()` in `Add()` and `Delete()` to apply per-operation TTLs explicitly

## Configuration Example

```yaml
link:
  hosted_zone_id: 'Z00000000000000000000'
  # TTL for Route53 ADD (UPSERT) operation cache (default: 5m)
  # Increasing this reduces UPSERT API call frequency
  add_cache_ttl: 1h
  # TTL for Route53 DELETE operation cache (default: 5m)
  # Setting this longer than the ECS stopped task retention (~1h) also prevents duplicate DELETE errors
  delete_cache_ttl: 2h
```

## Testing

```bash
go test ./...
```

## References

- [Route 53 API limits](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html)
- [ChangeResourceRecordSets – PriorRequestNotComplete](https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html)